### PR TITLE
Remove caches directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.iml
 .gradle
 /local.properties
+/.idea/caches
 /.idea/libraries
 /.idea/modules.xml
 /.idea/workspace.xml

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 /local.properties
 /.idea/caches
 /.idea/libraries
+/.idea/misc.xml
 /.idea/modules.xml
+/.idea/vcs.xml
 /.idea/workspace.xml
 .DS_Store
 /build


### PR DESCRIPTION
It is wrong to add a binary file to a repo. This will exclude any cache binaries generated by intellij to be uploaded to this repo.